### PR TITLE
Ignore /.vagrant/ directory

### DIFF
--- a/src/Loadsys/Composer/PuphpetReleaseInstaller.php
+++ b/src/Loadsys/Composer/PuphpetReleaseInstaller.php
@@ -105,6 +105,7 @@ class PuphpetReleaseInstaller extends LibraryInstaller {
 		$required = [
 			'/Vagrantfile',
 			'/puphpet/',
+			'/.vagrant/',
 		];
 
 		try {

--- a/tests/integration/simulate-composer-install.sh
+++ b/tests/integration/simulate-composer-install.sh
@@ -184,6 +184,9 @@ testGitignore () {
 
 	grep -qe '^/puphpet/$' "${BUILD_DIR}/.gitignore"
 	assertTrue ".gitignore must have a '/puphpet/' entry." "$?"
+
+	grep -qe '^/.vagrant/$' "${BUILD_DIR}/.gitignore"
+	assertTrue ".gitignore must have a '/.vagrant/' entry." "$?"
 }
 
 testPuphpetDir () {


### PR DESCRIPTION
It becomes apparent once up and running that a `.vagrant/` directory exists that should be ignored.