### PR TITLE
Properly handle consuming projects without a .gitignore

### DIFF
--- a/src/Loadsys/Composer/PuphpetReleaseInstaller.php
+++ b/src/Loadsys/Composer/PuphpetReleaseInstaller.php
@@ -101,6 +101,12 @@ class PuphpetReleaseInstaller extends LibraryInstaller {
 	 *
 	 */
 	protected function checkGitIgnore($package) {
+		$gitFolder = getcwd() . DS . '.git' . DS;
+
+		if (!file_exists($gitFolder)) {
+			return;
+		}
+
 		$gitignoreFile = getcwd() . DS . '.gitignore';
 		$required = [
 			'/Vagrantfile',
@@ -108,17 +114,15 @@ class PuphpetReleaseInstaller extends LibraryInstaller {
 			'/.vagrant/',
 		];
 
-		try {
-			$lines = file($gitignoreFile, FILE_IGNORE_NEW_LINES);
-		} catch (Exception $e) {
-			return;
-		}
+		touch($gitignoreFile);
+		$lines = file($gitignoreFile, FILE_IGNORE_NEW_LINES);
 
 		foreach ($required as $entry) {
 			if (!in_array($entry, $lines)) {
 				$lines[] = $entry;
 			}
 		}
+
 		file_put_contents($gitignoreFile, implode(PHP_EOL, $lines));
 	}
 }

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,3 +1,0 @@
-# Intentionally empty.
-# The install process should add entries for
-# `/Vagrantfile` and `/puphpet/` to this file.

--- a/tests/integration/simulate-composer-install.sh
+++ b/tests/integration/simulate-composer-install.sh
@@ -111,6 +111,7 @@ shopt -s dotglob
 (
 	cd "${TEST_DIR}"
 	cp -R * "${BUILD_DIR}/"
+	mkdir "${BUILD_DIR}/.git/"
 )
 
 shopt -u dotglob extglob


### PR DESCRIPTION
Found this during my testing, a nice big red error if the consuming project doesn't have a `.gitignore` file.

```shell
 ❯ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing symfony/filesystem (v2.6.6)
    Loading from cache

  - Installing loadsys/puphpet-release-composer-installer (0.0.4)
    Loading from cache

  - Installing loadsys/puphpet-release (dev-master 0d02e12)
    Cloning 0d02e12455a9f1c6140705ff3bd7930607a68ac7

  [ErrorException]
  file(/private/tmp/puppet-release-test/.gitignore): failed to open stream: No such file or directory
```

Using PHP's `touch()` prevents this error from occurring.