### PR TITLE
Use a more "default" folder structure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[travis.yml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# Ignore composer deps.
+/build/
 /vendor/
-
-# Ignore the folder we use when testing the installer.
-/build/*
+.php_cs.cache

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This installer is responsible for performing post-`composer install` actions for
 When this package is included in another project via composer, the installer fires a number of additional actions in order to address some of the incompatibilities between puphpet's default setup and the requirements for Vagrant (such as the `Vagrantfile` living in the project's root directory instead of the composer-installed `/vendors/loadsys/puphpet-release/release/` folder.)
 
 * Copies a Vagrantfile into the consuming project's root folder.
-* Copies a puphpet/ folder into the consuming project's root folder. 
+* Copies a puphpet/ folder into the consuming project's root folder.
 * Copies the consuming project's `/puphpet.yaml` into the correct place as `/puphpet/config.yaml`.
 * Tries to ensure that the consuming project's `/.gitignore` file contains the proper entries to ignore `/Vagrantfile` and `/puphpet/`, if it is present.
 
@@ -66,18 +66,18 @@ Testing this composer plugin is difficult because it involves at least 2 other p
 
 1. Run `./tests/integration/simulate-composer-install.sh`
 
-	The script will prompt you for any necessary information, reset the build/ dir for use, write the appropriate "composer.json" changes for you, and execute a `composer install` command for you in the build/ dir where you can review the results.
+    The script will prompt you for any necessary information, reset the build/ dir for use, write the appropriate "composer.json" changes for you, and execute a `composer install` command for you in the build/ dir where you can review the results.
 
-	* The `build/` folder should end up with a `Vagrantfile` and `puphpet/` folder in it.
-	* The sample `build/puphpet.yaml` file should have been copied to `build/puphpet/config.yaml`.
-	* The sample `.gitignore` file should have been "safely" updated to include the new additions to the "root" project folder (`build/`).
+    * The `build/` folder should end up with a `Vagrantfile` and `puphpet/` folder in it.
+    * The sample `build/puphpet.yaml` file should have been copied to `build/puphpet/config.yaml`.
+    * The sample `.gitignore` file should have been "safely" updated to include the new additions to the "root" project folder (`build/`).
 
 1. From here, the process loops through the following steps:
-	* Make changes to the puphpet-release or puphpet-release-composer-installer projects.
-	* **Commit** the changes to your working branch.
-	* Run `./tests/integration/simulate-composer-install.sh` again.
-	* Check the results in the `build/` directory.
-	* Repeat.
+    * Make changes to the puphpet-release or puphpet-release-composer-installer projects.
+    * **Commit** the changes to your working branch.
+    * Run `./tests/integration/simulate-composer-install.sh` again.
+    * Check the results in the `build/` directory.
+    * Repeat.
 
 1. Once you're satisfied with the results, push your branch and submit a PR.
 

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,10 @@
         "class": "Loadsys\\Composer\\PuphpetReleaseInstallerPlugin"
     },
     "require": {
-        "composer-plugin-api": "1.0.0",
-        "symfony/filesystem": "~2.6"
+        "composer-plugin-api": "^1.0"
     },
     "require-dev": {
-        "composer/composer": "1.0.*@dev",
-        "phpunit/phpunit": "~4.1"
+        "composer/composer": "1.0.x-dev",
+        "phpunit/phpunit": "^4.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,11 @@
     "name": "loadsys/puphpet-release-composer-installer",
     "description": "Provides a composer custom installer that works with `loadsys/puphpet-release` to add a PuPHPet.com vagrant box to a project via composer. DANGEROUS! Overwrites non-vendor files! Seriously, don't use this, or read the readme VERY carefully.",
     "keywords": [
-    	"puphpet",
-    	"vagrant",
-    	"dangerous",
-    	"do-not-use",
-    	"overwrites-files"
+        "puphpet",
+        "vagrant",
+        "dangerous",
+        "do-not-use",
+        "overwrites-files"
     ],
     "type": "composer-plugin",
     "license": "MIT",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit
-	backupGlobals="false"
-	backupStaticAttributes="false"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	syntaxCheck="false"
-	bootstrap="tests/bootstrap.php"
->
-	<testsuites>
-		<testsuite name="Test Suite">
-			<directory>tests/Loadsys/Composer</directory>
-		</testsuite>
-	</testsuites>
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    testsuite="Unit"
+    bootstrap="./tests/bootstrap.php"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    checkForUnintentionallyCoveredCode="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestSize="false"
+    forceCoversAnnotation="true"
+    mapTestClassNameToCoveredClassName="true"
+    verbose="true"
+    >
 
-	<filter>
-		<whitelist>
-			<directory>src/Loadsys/Composer</directory>
-		</whitelist>
-	</filter>
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="apc.enable_cli" value="1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Loadsys/Composer</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true" showOnlySummary="true"/>
+    </logging>
+
 </phpunit>

--- a/src/Loadsys/Composer/PuphpetReleaseInstaller.php
+++ b/src/Loadsys/Composer/PuphpetReleaseInstaller.php
@@ -51,7 +51,6 @@ class PuphpetReleaseInstaller extends LibraryInstaller
         }
 
         $this->mirrorReleaseItems($package);
-        $this->copyConfigFile($package);
         $this->checkGitignore($package);
     }
 
@@ -81,20 +80,6 @@ class PuphpetReleaseInstaller extends LibraryInstaller
 
         $filesystem = new Filesystem();
         $filesystem->mirror($releaseDir, $targetDir, $releaseItems, ['override' => true]);
-    }
-
-    /**
-     * Search for a config file in the consuming project and copy it into
-     * place if present.
-     *
-     */
-    protected function copyConfigFile($package)
-    {
-        $configFilePath = getcwd() . DS . 'puphpet.yaml';
-        $targetPath = getcwd() . DS . 'puphpet' . DS . 'config.yaml';
-        if (is_readable($configFilePath)) {
-            copy($configFilePath, $targetPath);
-        }
     }
 
     /**

--- a/src/Loadsys/Composer/PuphpetReleaseInstaller.php
+++ b/src/Loadsys/Composer/PuphpetReleaseInstaller.php
@@ -2,127 +2,130 @@
 
 namespace Loadsys\Composer;
 
-// Needed for LibraryInstaller:
 use Composer\Package\PackageInterface;
 use Composer\Installer\LibraryInstaller;
-
-// Needed for copying the release folder to the root.
-use \RecursiveDirectoryIterator;
-use \RecursiveCallbackFilterIterator;
-use \RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+use RecursiveCallbackFilterIterator;
+use RecursiveIteratorIterator;
 use Symfony\Component\Filesystem\Filesystem;
 
 if (!defined('DS')) {
-	define('DS', DIRECTORY_SEPARATOR);
+    define('DS', DIRECTORY_SEPARATOR);
 }
 
 /**
  * Custom installer and event handler.
  *
  * Ensures that a package with type=puphpet-release has its `release/`
- * subfolder copied into the project root, and associated configs copied
+ * sub-folder copied into the project root, and associated configs copied
  * into the `puphpet/` folder afterwards.
  */
-class PuphpetReleaseInstaller extends LibraryInstaller {
+class PuphpetReleaseInstaller extends LibraryInstaller
+{
 
-	/**
-	 * Defines the `type`s of composer packages to which this installer applies.
-	 *
-	 * A project's composer.json file must specify `"type": "puphpet-release"`
-	 * in order to trigger this installer.
-	 *
-	 * @param string $packageType The `type` specified in the consuming project's composer.json.
-	 * @return bool True if this installer should be activated for the package in question, false if not.
-	 */
-	public function supports($packageType) {
-		return 'puphpet-release' === $packageType;
-	}
+    /**
+     * Defines the `type`s of composer packages to which this installer applies.
+     *
+     * A project's composer.json file must specify `"type": "puphpet-release"`
+     * in order to trigger this installer.
+     *
+     * @param string $packageType The `type` specified in the consuming project's composer.json.
+     * @return bool True if this installer should be activated for the package in question, false if not.
+     */
+    public function supports($packageType)
+    {
+        return 'puphpet-release' === $packageType;
+    }
 
-	/**
-	 * Override LibraryInstaller::installCode() to hook in additional post-download steps.
-	 *
-	 * @param InstalledRepositoryInterface $repo    repository in which to check
-	 * @param PackageInterface             $package package instance
-	 */
-	protected function installCode(PackageInterface $package) {
-		parent::installCode($package);
+    /**
+     * Override LibraryInstaller::installCode() to hook in additional post-download steps.
+     *
+     * @param PackageInterface $package Package instance
+     */
+    protected function installCode(PackageInterface $package)
+    {
+        parent::installCode($package);
 
-		if (!$this->supports($package->getType())) {
-			return;
-		}
-		$this->mirrorReleaseItems($package);
-		$this->copyConfigFile($package);
-		$this->checkGitignore($package);
-	}
+        if (!$this->supports($package->getType())) {
+            return;
+        }
 
-	/**
-	 * Mirror (copy or delete, only as necessary) items from the installed
-	 * package's release/ folder into the target directory.
-	 *
-	 */
-	protected function mirrorReleaseItems($package) {
-		// Copy everything from the release/ subfolder to the project root.
-		$releaseDir = $this->getInstallPath($package) . DS . 'release';
-		$targetDir = getcwd();
-		$acceptList = [
-			'Vagrantfile',
-			'puphpet',
-		];
+        $this->mirrorReleaseItems($package);
+        $this->copyConfigFile($package);
+        $this->checkGitignore($package);
+    }
 
-		// Return true if the first part of the subpath for the current file exists in the accept array.
-		$acceptFunc = function ($current, $key, $iterator) use ($acceptList) {
-			$pathComponents = explode(DS, $iterator->getSubPathname());
-			return in_array($pathComponents[0], $acceptList);
-		};
-		$dirIterator = new RecursiveDirectoryIterator($releaseDir, RecursiveDirectoryIterator::SKIP_DOTS);
-		$filterIterator = new RecursiveCallbackFilterIterator($dirIterator, $acceptFunc);
-		$releaseItems = new RecursiveIteratorIterator($filterIterator, RecursiveIteratorIterator::SELF_FIRST);
+    /**
+     * Mirror (copy or delete, only as necessary) items from the installed
+     * package's release/ folder into the target directory.
+     *
+     */
+    protected function mirrorReleaseItems($package)
+    {
+        // Copy everything from the release/ subfolder to the project root.
+        $releaseDir = $this->getInstallPath($package) . DS . 'release';
+        $targetDir = getcwd();
+        $acceptList = [
+            'Vagrantfile',
+            'puphpet',
+        ];
 
-		$filesystem = new Filesystem();
-		$filesystem->mirror($releaseDir, $targetDir, $releaseItems, ['override' => true]);
-	}
+        // Return true if the first part of the subpath for the current file exists in the accept array.
+        $acceptFunc = function ($current, $key, RecursiveDirectoryIterator $iterator) use ($acceptList) {
+            $pathComponents = explode(DS, $iterator->getSubPathname());
+            return in_array($pathComponents[0], $acceptList, true);
+        };
+        $dirIterator = new RecursiveDirectoryIterator($releaseDir, RecursiveDirectoryIterator::SKIP_DOTS);
+        $filterIterator = new RecursiveCallbackFilterIterator($dirIterator, $acceptFunc);
+        $releaseItems = new RecursiveIteratorIterator($filterIterator, RecursiveIteratorIterator::SELF_FIRST);
 
-	/**
-	 * Search for a config file in the consuming project and copy it into
-	 * place if present.
-	 *
-	 */
-	protected function copyConfigFile($package) {
-		$configFilePath = getcwd() . DS . 'puphpet.yaml';
-		$targetPath = getcwd() . DS . 'puphpet' . DS . 'config.yaml';
-		if (is_readable($configFilePath)) {
-			copy($configFilePath, $targetPath);
-		}
-	}
+        $filesystem = new Filesystem();
+        $filesystem->mirror($releaseDir, $targetDir, $releaseItems, ['override' => true]);
+    }
 
-	/**
-	 * Check that release items copied into the consuming project are
-	 * properly ignored in source control (very, VERY crudely.)
-	 *
-	 */
-	protected function checkGitIgnore($package) {
-		$gitFolder = getcwd() . DS . '.git' . DS;
+    /**
+     * Search for a config file in the consuming project and copy it into
+     * place if present.
+     *
+     */
+    protected function copyConfigFile($package)
+    {
+        $configFilePath = getcwd() . DS . 'puphpet.yaml';
+        $targetPath = getcwd() . DS . 'puphpet' . DS . 'config.yaml';
+        if (is_readable($configFilePath)) {
+            copy($configFilePath, $targetPath);
+        }
+    }
 
-		if (!file_exists($gitFolder)) {
-			return;
-		}
+    /**
+     * Check that release items copied into the consuming project are
+     * properly ignored in source control (very, VERY crudely.)
+     *
+     */
+    protected function checkGitignore($package)
+    {
+        $gitFolder = getcwd() . DS . '.git' . DS;
 
-		$gitignoreFile = getcwd() . DS . '.gitignore';
-		$required = [
-			'/Vagrantfile',
-			'/puphpet/',
-			'/.vagrant/',
-		];
+        if (!file_exists($gitFolder)) {
+            return;
+        }
 
-		touch($gitignoreFile);
-		$lines = file($gitignoreFile, FILE_IGNORE_NEW_LINES);
+        $gitignoreFile = getcwd() . DS . '.gitignore';
+        $required = [
+            '/Vagrantfile',
+            '/puphpet/',
+            '/.vagrant/',
+        ];
 
-		foreach ($required as $entry) {
-			if (!in_array($entry, $lines)) {
-				$lines[] = $entry;
-			}
-		}
+        touch($gitignoreFile);
+        $lines = file($gitignoreFile, FILE_IGNORE_NEW_LINES);
 
-		file_put_contents($gitignoreFile, implode(PHP_EOL, $lines));
-	}
+        foreach ($required as $entry) {
+            if (!in_array($entry, $lines, true)) {
+                $lines[] = $entry;
+            }
+        }
+
+        file_put_contents($gitignoreFile, implode(PHP_EOL, $lines));
+    }
 }

--- a/src/Loadsys/Composer/PuphpetReleaseInstaller.php
+++ b/src/Loadsys/Composer/PuphpetReleaseInstaller.php
@@ -112,9 +112,14 @@ class PuphpetReleaseInstaller extends LibraryInstaller
 
         $gitignoreFile = getcwd() . DS . '.gitignore';
         $required = [
-            '/Vagrantfile',
-            '/puphpet/',
             '/.vagrant/',
+            '/puphpet/files/dot/',
+            '/puphpet/puppet/',
+            '/puphpet/ruby/',
+            '/puphpet/shell/',
+            '/puphpet/vagrant/',
+            '/puphpet/config-custom.yaml',
+            '/Vagrantfile',
         ];
 
         touch($gitignoreFile);

--- a/src/Loadsys/Composer/PuphpetReleaseInstaller.php
+++ b/src/Loadsys/Composer/PuphpetReleaseInstaller.php
@@ -131,6 +131,6 @@ class PuphpetReleaseInstaller extends LibraryInstaller
             }
         }
 
-        file_put_contents($gitignoreFile, implode(PHP_EOL, $lines));
+        file_put_contents($gitignoreFile, implode(PHP_EOL, $lines) . PHP_EOL);
     }
 }

--- a/src/Loadsys/Composer/PuphpetReleaseInstaller.php
+++ b/src/Loadsys/Composer/PuphpetReleaseInstaller.php
@@ -72,7 +72,7 @@ class PuphpetReleaseInstaller extends LibraryInstaller
         // Return true if the first part of the subpath for the current file exists in the accept array.
         $acceptFunc = function ($current, $key, RecursiveDirectoryIterator $iterator) use ($acceptList) {
             $pathComponents = explode(DS, $iterator->getSubPathname());
-            return in_array($pathComponents[0], $acceptList, true);
+            return in_array($pathComponents[0], $acceptList, true) && end($pathComponents) !== 'empty';
         };
         $dirIterator = new RecursiveDirectoryIterator($releaseDir, RecursiveDirectoryIterator::SKIP_DOTS);
         $filterIterator = new RecursiveCallbackFilterIterator($dirIterator, $acceptFunc);

--- a/src/Loadsys/Composer/PuphpetReleaseInstallerPlugin.php
+++ b/src/Loadsys/Composer/PuphpetReleaseInstallerPlugin.php
@@ -2,7 +2,6 @@
 
 namespace Loadsys\Composer;
 
-// Needed for PluginInterface:
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
@@ -11,19 +10,22 @@ use Composer\Plugin\PluginInterface;
  * Plugin entry point.
  *
  */
-class PuphpetReleaseInstallerPlugin implements PluginInterface {
+class PuphpetReleaseInstallerPlugin implements PluginInterface
+{
 
-	/**
-	 * Activate the plugin (called from {@see \Composer\Plugin\PluginManager})
-	 *
-	 * All we need to do is register our custom installer class.
-	 *
-	 * @param \Composer\Composer $composer The active instance of the composer base class.
-	 * @param \Composer\IO\IOInterface $io The I/O instance.
-	 * @return void
-	 */
-	public function activate(Composer $composer, IOInterface $io) {
-		$installer = new PuphpetReleaseInstaller($io, $composer);
-		$composer->getInstallationManager()->addInstaller($installer);
-	}
+    /**
+     * Activate the plugin (called from {@see \Composer\Plugin\PluginManager})
+     *
+     * All we need to do is register our custom installer class.
+     *
+     * @param \Composer\Composer $composer The active instance of the composer base class.
+     * @param \Composer\IO\IOInterface $io The I/O instance.
+     * @return void
+     */
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $installer = new PuphpetReleaseInstaller($io, $composer);
+
+        $composer->getInstallationManager()->addInstaller($installer);
+    }
 }

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,15 +1,19 @@
 <?php
-function includeIfExists($file) {
-    if (file_exists($file)) {
-        return include $file;
-    }
+
+function includeIfExists($file)
+{
+    return (file_exists($file)) ? include $file : false;
 }
+
 if (
-    (!$loader = includeIfExists(__DIR__ . '/../vendor/autoload.php'))
-    && (!$loader = includeIfExists(__DIR__ . '/../../../autoload.php'))
+    (!$loader = includeIfExists(__DIR__ . '/../vendor/autoload.php')) &&
+    (!$loader = includeIfExists(__DIR__ . '/../../../autoload.php'))
 ) {
-    die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
-        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
-        'php composer.phar install'.PHP_EOL);
+    die(
+        'You must set up the project dependencies, run the following commands:' . PHP_EOL .
+        'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
 }
+
 return $loader;

--- a/tests/Loadsys/Composer/Test/PuphpetReleaseInstallerPluginTest.php
+++ b/tests/Loadsys/Composer/Test/PuphpetReleaseInstallerPluginTest.php
@@ -1,20 +1,33 @@
 <?php
+
 namespace Loadsys\Composer\Test;
 
+use Composer\IO\IOInterface;
 use Loadsys\Composer\PuphpetReleaseInstallerPlugin;
-use Composer\Repository\RepositoryManager;
-use Composer\Repository\InstalledArrayRepository;
 use Composer\Package\Package;
-use Composer\Package\RootPackage;
-use Composer\Package\Link;
-use Composer\Package\Version\VersionParser;
 use Composer\Composer;
 use Composer\Config;
 
-class PuphpetReleaseInstallerPluginTest extends \PHPUnit_Framework_TestCase {
+class PuphpetReleaseInstallerPluginTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Package
+     */
     private $package;
+
+    /**
+     * @var IOInterface
+     */
     private $io;
+
+    /**
+     * @var Composer
+     */
     private $composer;
+
+    /**
+     * @var PuphpetReleaseInstallerPlugin
+     */
     private $plugin;
 
     /**
@@ -22,7 +35,8 @@ class PuphpetReleaseInstallerPluginTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp()
+    {
         $this->package = new Package('CamelCased', '1.0', '1.0');
         $this->io = $this->getMock('Composer\IO\IOInterface');
         $this->composer = new Composer();
@@ -34,11 +48,9 @@ class PuphpetReleaseInstallerPluginTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function tearDown() {
-        unset($this->package);
-        unset($this->io);
-        unset($this->composer);
-        unset($this->plugin);
+    public function tearDown()
+    {
+        unset($this->package, $this->io, $this->composer, $this->plugin);
     }
 
     /**
@@ -47,10 +59,11 @@ class PuphpetReleaseInstallerPluginTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testActivate() {
+    public function testActivate()
+    {
         $this->composer = $this->getMock('Composer\Composer', [
-        	'getInstallationManager',
-        	'addInstaller'
+            'getInstallationManager',
+            'addInstaller'
         ]);
         $this->composer->setConfig(new Config(false));
 

--- a/tests/Loadsys/Composer/Test/PuphpetReleaseInstallerTest.php
+++ b/tests/Loadsys/Composer/Test/PuphpetReleaseInstallerTest.php
@@ -38,29 +38,55 @@ class PuphpetReleaseInstallerTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->package = new Package('CamelCased', '1.0', '1.0');
-        $this->io = $this->getMock('Composer\IO\IOInterface');
+        parent::setUp();
+        $this->package = $this->getMockBuilder(Package::class)
+            ->setConstructorArgs(array(md5(mt_rand()), '1.0.0.0', '1.0.0'))
+            ->getMock();//$this->createPackageMock(); //new Package('CamelCased', '1.0', '1.0');
+        $this->io = $this->getMock(IOInterface::class);
         $this->composer = new Composer();
         $this->composer->setConfig(new Config(false));
+        $this->repository = $this->getMock(InstalledRepositoryInterface::class);
     }
 
     /**
-     * tearDown
+     * Runs after each test.
      *
      * @return void
      */
     public function tearDown()
     {
-        unset($this->package, $this->io, $this->composer);
+        parent::tearDown();
+        //unset($this->package, $this->io, $this->composer);
     }
 
     /**
-     * testNothing
-     *
+     * @test
      * @return void
      */
-    public function testNothing()
+    public function itShouldSupportThePuphpetReleasePackageType()
     {
-        $this->markTestIncomplete('@TODO: No tests written for PuphpetReleaseInstaller.');
+        $installer = new PuphpetReleaseInstaller($this->io, $this->composer);
+
+        static::assertTrue($installer->supports('puphpet-release'));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function itShouldCallInstallCodeWhenInstalling()
+    {
+        /* @var PuphpetReleaseInstaller|\PHPUnit_Framework_MockObject_MockObject $installer */
+        $installer = $this->getMock(PuphpetReleaseInstaller::class, [
+            'initializeVendorDir',
+            'getInstallPath',
+            'removeBinaries',
+            'installCode',
+            'installBinaries'
+        ], [], '', false);
+
+        $installer->expects(static::once())->method('installCode')->with($this->package);
+
+        $installer->install($this->repository, $this->package);
     }
 }

--- a/tests/Loadsys/Composer/Test/PuphpetReleaseInstallerTest.php
+++ b/tests/Loadsys/Composer/Test/PuphpetReleaseInstallerTest.php
@@ -1,29 +1,45 @@
 <?php
+
 namespace Loadsys\Composer\Test;
 
-use Loadsys\Composer\PuphpetReleaseInstaller;
-use Composer\Repository\RepositoryManager;
-use Composer\Repository\InstalledArrayRepository;
+use Composer\IO\IOInterface;
 use Composer\Package\Package;
-use Composer\Package\RootPackage;
-use Composer\Package\Link;
-use Composer\Package\Version\VersionParser;
 use Composer\Composer;
 use Composer\Config;
+use Composer\Repository\InstalledRepositoryInterface;
+use Loadsys\Composer\PuphpetReleaseInstaller;
 
-class PuphpetReleaseInstallerTest extends \PHPUnit_Framework_TestCase {
+class PuphpetReleaseInstallerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Package
+     */
     private $package;
+
+    /**
+     * @var Composer
+     */
     private $composer;
+
+    /**
+     * @var IOInterface
+     */
     private $io;
 
     /**
-     * setUp
+     * @var InstalledRepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * Runs before each test.
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp()
+    {
         $this->package = new Package('CamelCased', '1.0', '1.0');
-        $this->io = $this->getMock('Composer\IO\PackageInterface');
+        $this->io = $this->getMock('Composer\IO\IOInterface');
         $this->composer = new Composer();
         $this->composer->setConfig(new Config(false));
     }
@@ -33,10 +49,9 @@ class PuphpetReleaseInstallerTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function tearDown() {
-        unset($this->package);
-        unset($this->io);
-        unset($this->composer);
+    public function tearDown()
+    {
+        unset($this->package, $this->io, $this->composer);
     }
 
     /**
@@ -44,7 +59,8 @@ class PuphpetReleaseInstallerTest extends \PHPUnit_Framework_TestCase {
      *
      * @return void
      */
-    public function testNothing() {
+    public function testNothing()
+    {
         $this->markTestIncomplete('@TODO: No tests written for PuphpetReleaseInstaller.');
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,4 @@
 <?php
+
 $loader = require dirname(__DIR__) . '/src/bootstrap.php';
 $loader->add('Loadsys\Composer\Test', __DIR__);

--- a/tests/integration/composer.json
+++ b/tests/integration/composer.json
@@ -1,25 +1,25 @@
 {
-	"name": "me/test-composer-installer",
-	"description": "Template file for testing the puphpet-release-composer-installer. Written to ../tmp/ with proper branch names.",
-	"require": {
-		"loadsys/puphpet-release-composer-installer": "dev-PRCI_BRANCH_NAME",
-		"loadsys/puphpet-release": "dev-PR_BRANCH_NAME"
-	},
-	"repositories": [
-		{
-			"packagist": false
-		},
-		{
-			"type": "vcs",
-			"url": "https://github.com/symfony/Filesystem.git"
-		},
-		{
-			"type": "vcs",
-			"url": "PR_DIRECTORY"
-		},
-		{
-			"type": "vcs",
-			"url": "../"
-		}
-	]
+    "name": "me/test-composer-installer",
+    "description": "Template file for testing the puphpet-release-composer-installer. Written to ../tmp/ with proper branch names.",
+    "require": {
+        "loadsys/puphpet-release-composer-installer": "dev-PRCI_BRANCH_NAME",
+        "loadsys/puphpet-release": "dev-PR_BRANCH_NAME"
+    },
+    "repositories": [
+        {
+            "packagist": false
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/symfony/Filesystem.git"
+        },
+        {
+            "type": "vcs",
+            "url": "PR_DIRECTORY"
+        },
+        {
+            "type": "vcs",
+            "url": "../"
+        }
+    ]
 }

--- a/tests/integration/simulate-composer-install.sh
+++ b/tests/integration/simulate-composer-install.sh
@@ -227,10 +227,13 @@ testGitignore () {
 
 testPuphpetDir () {
     [ -d "${BUILD_DIR}/puphpet" ]
-    assertTrue "puphpet/ directory must be present." "$?" || return
+    assertTrue "'puphpet/' directory must be present." "$?" || return
 
     [ -f "${BUILD_DIR}/Vagrantfile" ]
-    assertTrue "Vagrantfile must be present." "$?" || return
+    assertTrue "'Vagrantfile' must be present." "$?" || return
+
+    [ ! -f "${BUILD_DIR}/puphpet/files/exec-always/empty" ]
+    assertTrue "'empty' files should not be present." "$?" || return
 }
 
 # Load and run shUnit2

--- a/tests/integration/simulate-composer-install.sh
+++ b/tests/integration/simulate-composer-install.sh
@@ -2,7 +2,7 @@
 
 #---------------------------------------------------------------------
 usage () {
-	cat <<EOT
+    cat <<EOT
 
 ${0##*/}
     Simulates the operation of the \`composer install\` command using this project.
@@ -16,10 +16,10 @@ Options:
 
 EOT
 
-	exit 0
+    exit 0
 }
 if [ "$1" = '-h' ]; then
-	usage
+    usage
 fi
 
 
@@ -36,16 +36,16 @@ BUILD_DIR="${BASE_DIR}/build"
 # Set testing mode.
 TEST_MODE=
 if [ "$1" = '-t' ]; then
-	echo "## Setting test mode ON."
-	TEST_MODE="yes"
-	shift
+    echo "## Setting test mode ON."
+    TEST_MODE="yes"
+    shift
 fi
 
 
 # Make sure the build dir exists.
 if [ ! -d "${BUILD_DIR}" ]; then
-	echo "## Creating build directory."
-	mkdir -p "${BUILD_DIR}"
+    echo "## Creating build directory."
+    mkdir -p "${BUILD_DIR}"
 fi
 
 
@@ -54,29 +54,29 @@ echo "## Checking the symlink to the release project."
 RELEASE_PROJECT_SYMLINK="${BUILD_DIR}/release-project"
 
 if [ -h "${RELEASE_PROJECT_SYMLINK}" ]; then
-	RELEASE_PROJECT_PATH=$(readlink "${RELEASE_PROJECT_SYMLINK}")
+    RELEASE_PROJECT_PATH=$(readlink "${RELEASE_PROJECT_SYMLINK}")
 elif [ -d "${RELEASE_PROJECT_SYMLINK}" ]; then
-	RELEASE_PROJECT_PATH="${RELEASE_PROJECT_SYMLINK}"
+    RELEASE_PROJECT_PATH="${RELEASE_PROJECT_SYMLINK}"
 elif [ "${TEST_MODE}" ]; then
-	echo "!! No symlink to the release project working copy"
-	echo "!! is present at \`${RELEASE_PROJECT_SYMLINK}\`."
-	echo "!! Please create it."
-	exit 1
+    echo "!! No symlink to the release project working copy"
+    echo "!! is present at \`${RELEASE_PROJECT_SYMLINK}\`."
+    echo "!! Please create it."
+    exit 1
 else
-	read -p "  Please provide the path to the release project working copy > " RELEASE_PROJECT_PATH
-	ln -s "${RELEASE_PROJECT_PATH}" "${RELEASE_PROJECT_SYMLINK}"
+    read -p "  Please provide the path to the release project working copy > " RELEASE_PROJECT_PATH
+    ln -s "${RELEASE_PROJECT_PATH}" "${RELEASE_PROJECT_SYMLINK}"
 fi
 
 
 # Set the release project's branch name to use.
 if [ "${TEST_MODE}" ]; then
-	# In testing mode, just default to master when no arg provided.
-	RELEASE_PROJECT_BRANCH=${1:-master}
-	shift
+    # In testing mode, just default to master when no arg provided.
+    RELEASE_PROJECT_BRANCH=${1:-master}
+    shift
 elif [ -n "$1" ]; then
-	RELEASE_PROJECT_BRANCH=$1
+    RELEASE_PROJECT_BRANCH=$1
 else
-	read -p "  Please provide the branch name from the release project to use > " RELEASE_PROJECT_BRANCH
+    read -p "  Please provide the branch name from the release project to use > " RELEASE_PROJECT_BRANCH
 fi
 echo "## Release project branch name is \`${RELEASE_PROJECT_BRANCH}\`."
 
@@ -89,27 +89,27 @@ echo "## Release project branch name is \`${RELEASE_PROJECT_BRANCH}\`."
 # echo "   TRAVIS_BRANCH=       $TRAVIS_BRANCH"
 
 if [ -n "${TRAVIS_TAG}" ]; then
-	echo ""
-	echo "!! Unable to perform integration tests against git tags in Travis !!"
-	echo ""
-	echo "   Travis does not identify the originating branch name when     "
-	echo "   executing a build for a git tag (TRAVIS_BRANCH is unhelpfully "
-	echo "   the same as TRAVIS_TAG), and Composer does not provide a      "
-	echo "   way to target a non-version-number tag name, so we can not    "
-	echo "   write a custom composer.json to complete this build.          "
-	echo ""
-	echo "   Exiting 0"
-	exit 0
+    echo ""
+    echo "!! Unable to perform integration tests against git tags in Travis !!"
+    echo ""
+    echo "   Travis does not identify the originating branch name when     "
+    echo "   executing a build for a git tag (TRAVIS_BRANCH is unhelpfully "
+    echo "   the same as TRAVIS_TAG), and Composer does not provide a      "
+    echo "   way to target a non-version-number tag name, so we can not    "
+    echo "   write a custom composer.json to complete this build.          "
+    echo ""
+    echo "   Exiting 0"
+    exit 0
 elif [[ -n "${TRAVIS_PULL_REQUEST}" && "${TRAVIS_PULL_REQUEST}" -ne "false" ]]; then
-	INSTALLER_PROJECT_BRANCH="pull/${TRAVIS_PULL_REQUEST}/merge"
-	(
-		cd "${BASE_DIR}" >/dev/null 2>&1
-		git checkout -qb $INSTALLER_PROJECT_BRANCH
-	)
+    INSTALLER_PROJECT_BRANCH="pull/${TRAVIS_PULL_REQUEST}/merge"
+    (
+        cd "${BASE_DIR}" >/dev/null 2>&1
+        git checkout -qb $INSTALLER_PROJECT_BRANCH
+    )
 elif [ -n "${TRAVIS_COMMIT}" ]; then
-	INSTALLER_PROJECT_BRANCH="${TRAVIS_BRANCH}#${TRAVIS_COMMIT}"
+    INSTALLER_PROJECT_BRANCH="${TRAVIS_BRANCH}#${TRAVIS_COMMIT}"
 else
-	INSTALLER_PROJECT_BRANCH=$( cd "${BASE_DIR}" >/dev/null 2>&1; git rev-parse --quiet --abbrev-ref HEAD 2>/dev/null )
+    INSTALLER_PROJECT_BRANCH=$( cd "${BASE_DIR}" >/dev/null 2>&1; git rev-parse --quiet --abbrev-ref HEAD 2>/dev/null )
 fi
 echo "## Installer project branch name is \`${INSTALLER_PROJECT_BRANCH}\`."
 
@@ -118,8 +118,8 @@ echo "## Installer project branch name is \`${INSTALLER_PROJECT_BRANCH}\`."
 echo "## Purging old files from build directory."
 shopt -s dotglob extglob
 (
-	cd "${BUILD_DIR}"
-	rm -rf !(.|..|.gitkeep|release-project|${SHUNIT_DOWNLOAD_VERSION})
+    cd "${BUILD_DIR}"
+    rm -rf !(.|..|.gitkeep|release-project|${SHUNIT_DOWNLOAD_VERSION})
 )
 
 
@@ -127,9 +127,9 @@ shopt -s dotglob extglob
 echo "## Populating the build directory."
 shopt -s dotglob
 (
-	cd "${TEST_DIR}"
-	cp -R * "${BUILD_DIR}/"
-	mkdir "${BUILD_DIR}/.git/"
+    cd "${TEST_DIR}"
+    cp -R * "${BUILD_DIR}/"
+    mkdir "${BUILD_DIR}/.git/"
 )
 
 shopt -u dotglob extglob
@@ -148,22 +148,22 @@ sed \
 # Execute the `composer install` command itself.
 echo "## Executing \`composer install\` in the build directory."
 COMPOSER_OUTPUT=$(
-	cd "${BUILD_DIR}/";
-	composer install --no-interaction --ignore-platform-reqs
+    cd "${BUILD_DIR}/";
+    composer install --no-interaction --ignore-platform-reqs
 )
 COMPOSER_EXIT_CODE=$?
 
 # End the script if test mode is OFF.
 if [ -z "${TEST_MODE}" ]; then
-	if [ "${COMPOSER_EXIT_CODE}" ]; then
-		echo "!! Composer installation failed. Examine the results in \`${BUILD_DIR}\`."
-		echo ''
-		echo "${COMPOSER_OUTPUT}"
-		exit $COMPOSER_EXIT_CODE
-	else
-		echo "## Done simulating \`composer install\`. Examine the results in \`${BUILD_DIR}\`."
-		exit 0
-	fi
+    if [ "${COMPOSER_EXIT_CODE}" ]; then
+        echo "!! Composer installation failed. Examine the results in \`${BUILD_DIR}\`."
+        echo ''
+        echo "${COMPOSER_OUTPUT}"
+        exit $COMPOSER_EXIT_CODE
+    else
+        echo "## Done simulating \`composer install\`. Examine the results in \`${BUILD_DIR}\`."
+        exit 0
+    fi
 fi
 
 
@@ -176,47 +176,46 @@ SHUNIT_TMP_DOWNLOAD="${BUILD_DIR}/${SHUNIT_DOWNLOAD_VERSION}.tgz"
 SHUNIT_EXTRACT_PATH="${BUILD_DIR}"
 SHUNIT_EXECUTABLE="${SHUNIT_EXTRACT_PATH}/${SHUNIT_DOWNLOAD_VERSION}/src/shunit2"
 if [ ! -x "${SHUNIT_EXECUTABLE}" ]; then
-	if [ ! -f "${SHUNIT_TMP_DOWNLOAD}" ]; then
-		echo "## Fetching shunit2."
-		curl -L \
-			--silent \
-			--output "${SHUNIT_TMP_DOWNLOAD}" \
-			$SHUNIT_FETCH_URL
-	fi
-	echo "## Unpacking shunit2."
-	tar zxf "${SHUNIT_TMP_DOWNLOAD}" -C "${SHUNIT_EXTRACT_PATH}"
+    if [ ! -f "${SHUNIT_TMP_DOWNLOAD}" ]; then
+        echo "## Fetching shunit2."
+        curl -L \
+            --silent \
+            --output "${SHUNIT_TMP_DOWNLOAD}" \
+            $SHUNIT_FETCH_URL
+    fi
+    echo "## Unpacking shunit2."
+    tar zxf "${SHUNIT_TMP_DOWNLOAD}" -C "${SHUNIT_EXTRACT_PATH}"
 fi
 
 
 # Define the tests to execute.
 echo "## Defining tests."
 testComposerExitCode () {
-	assertTrue "composer must not error during install.
+    assertTrue "composer must not error during install.
 
 ${COMPOSER_OUTPUT}
-		" "$COMPOSER_EXIT_CODE"
+        " "$COMPOSER_EXIT_CODE"
 }
 
 testGitignore () {
-	grep -qe '^/Vagrantfile$' "${BUILD_DIR}/.gitignore"
-	assertTrue ".gitignore must have a '/Vagrantfile' entry." "$?"
+    grep -qe '^/Vagrantfile$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/Vagrantfile' entry." "$?"
 
-	grep -qe '^/puphpet/$' "${BUILD_DIR}/.gitignore"
-	assertTrue ".gitignore must have a '/puphpet/' entry." "$?"
+    grep -qe '^/puphpet/$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/puphpet/' entry." "$?"
 
-	grep -qe '^/.vagrant/$' "${BUILD_DIR}/.gitignore"
-	assertTrue ".gitignore must have a '/.vagrant/' entry." "$?"
+    grep -qe '^/.vagrant/$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/.vagrant/' entry." "$?"
 }
 
 testPuphpetDir () {
-	[ -d "${BUILD_DIR}/puphpet" ]
-	assertTrue "puphpet/ directory must be present." "$?" || return
+    [ -d "${BUILD_DIR}/puphpet" ]
+    assertTrue "puphpet/ directory must be present." "$?" || return
 
-	grep -qe '^canary: "foo"$' "${BUILD_DIR}/puphpet/config.yaml"
-	assertTrue "puphpet.yaml file must be copied into puphpet/ directory." "$?"
+    grep -qe '^canary: "foo"$' "${BUILD_DIR}/puphpet/config.yaml"
+    assertTrue "puphpet.yaml file must be copied into puphpet/ directory." "$?"
 }
 
 # Load and run shUnit2
 echo "## Executing tests:"
 . "${SHUNIT_EXECUTABLE}"
-

--- a/tests/integration/simulate-composer-install.sh
+++ b/tests/integration/simulate-composer-install.sh
@@ -229,8 +229,8 @@ testPuphpetDir () {
     [ -d "${BUILD_DIR}/puphpet" ]
     assertTrue "puphpet/ directory must be present." "$?" || return
 
-    grep -qe '^canary: "foo"$' "${BUILD_DIR}/puphpet/config.yaml"
-    assertTrue "puphpet.yaml file must be copied into puphpet/ directory." "$?"
+    [ -f "${BUILD_DIR}/Vagrantfile" ]
+    assertTrue "Vagrantfile must be present." "$?" || return
 }
 
 # Load and run shUnit2

--- a/tests/integration/simulate-composer-install.sh
+++ b/tests/integration/simulate-composer-install.sh
@@ -221,6 +221,8 @@ testGitignore () {
 
     grep -qe '^/Vagrantfile$' "${BUILD_DIR}/.gitignore"
     assertTrue ".gitignore must have a '/Vagrantfile' entry." "$?"
+
+    assertEquals ".gitignore must end in a new line." 1 $(tail -c1 ${BUILD_DIR}/.gitignore | wc -l)
 }
 
 testPuphpetDir () {

--- a/tests/integration/simulate-composer-install.sh
+++ b/tests/integration/simulate-composer-install.sh
@@ -198,14 +198,29 @@ ${COMPOSER_OUTPUT}
 }
 
 testGitignore () {
-    grep -qe '^/Vagrantfile$' "${BUILD_DIR}/.gitignore"
-    assertTrue ".gitignore must have a '/Vagrantfile' entry." "$?"
-
-    grep -qe '^/puphpet/$' "${BUILD_DIR}/.gitignore"
-    assertTrue ".gitignore must have a '/puphpet/' entry." "$?"
-
     grep -qe '^/.vagrant/$' "${BUILD_DIR}/.gitignore"
     assertTrue ".gitignore must have a '/.vagrant/' entry." "$?"
+
+    grep -qe '^/puphpet/files/dot/$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/puphpet/files/dot/' entry." "$?"
+
+    grep -qe '^/puphpet/puppet/$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/puphpet/puppet/' entry." "$?"
+
+    grep -qe '^/puphpet/ruby/$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/puphpet/ruby/' entry." "$?"
+
+    grep -qe '^/puphpet/shell/$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/puphpet/shell/' entry." "$?"
+
+    grep -qe '^/puphpet/vagrant/$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/puphpet/vagrant/' entry." "$?"
+
+    grep -qe '^/puphpet/config-custom.yaml$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/puphpet/config-custom.yaml' entry." "$?"
+
+    grep -qe '^/Vagrantfile$' "${BUILD_DIR}/.gitignore"
+    assertTrue ".gitignore must have a '/Vagrantfile' entry." "$?"
 }
 
 testPuphpetDir () {


### PR DESCRIPTION
In relation to #14, here are the changes related to the folder structure (and some PSR-2 formatting):

> This means the .gitignore rules that are managed now look like this:
> 
> ```
> /.vagrant/
> /puphpet/files/dot/
> /puphpet/puppet/
> /puphpet/ruby/
> /puphpet/shell/
> /puphpet/vagrant/
> /puphpet/config-custom.yaml
> /Vagrantfile
> ```
> 
> And files such as these are allowed to be versioned:
> 
> ```
> /puphpet/files/exec-once-unprivileged/dotfiles.sh
> /puphpet/config.yaml
> ```
> 
> In summary, my changes do away with the root puphpet.yaml in favor of the intended config location,  there is no longer a needed to move files around (deizel@642ea88), and by deleting the default config.yaml there isn't a chance of it getting wiped out during updates.

Needs some more testing/documentation before merging.
